### PR TITLE
fix(ci): drop native:sqlite:ensure + fix action versions in Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,12 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      
+
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
@@ -50,9 +50,6 @@ jobs:
         run: |
           npm install --legacy-peer-deps
           npm install -D @changesets/cli @changesets/changelog-github --legacy-peer-deps
-
-      - name: Ensure native SQLite binding
-        run: npm run native:sqlite:ensure
 
       - name: Upgrade npm for Trusted Publishing
         run: npm install -g npm@latest


### PR DESCRIPTION
## Summary

Mirror of the ci.yml fix already on main. The Release workflow has the same template-bugs:

- `native:sqlite:ensure` script doesn't exist in dcyfr-ai-web (Next.js frontend, no native bindings) — removed the step
- `actions/checkout@v6` and `actions/setup-node@v6` don't exist in the public registry — pinned to v4

This unblocks the Release workflow, which has been failing on every push to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)