### PR TITLE
fix(release): add npm run release for changesets/action

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "db:migrate": "tsx src/db/migrate.ts",
     "db:seed": "tsx src/db/seed.ts",
     "db:studio": "drizzle-kit studio",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "release": "changeset publish"
   },
   "dependencies": {
     "@dcyfr/utils": "file:vendor/dcyfr-utils",


### PR DESCRIPTION
Release workflow's `changesets/action@v1` calls `publish: npm run release` but no `release` script exists, so every run errors with `Missing script: "release"`.

Added `"release": "changeset publish"`. The package is `private: true`, so changeset publish is a no-op — but the script must exist for the action to invoke it cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)