### PR TITLE
chore(security): add CodeQL JS/TS analysis workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,38 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 9 * * 1'
+
+permissions:
+  security-events: write
+  contents: read
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

Adds a CodeQL static-analysis workflow scanning JavaScript + TypeScript with the `security-and-quality` query suite. Runs on push, PR, and weekly (Mon 09:00 UTC).

## Why

CodeQL is free for public repos. Findings flow into the Security tab as code-scanning alerts (140+ patterns: SQLi, XSS, path traversal, hardcoded creds, unsafe deserialization, prototype pollution, etc.).

## Test plan

- [ ] Workflow runs successfully on first push
- [ ] First scan completes within ~30 min (configurable timeout-minutes)
- [ ] Any pre-existing findings surface in repo Security tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)