### PR TITLE
chore(security): add Semgrep workflow with semgrep.dev integration

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,33 @@
+name: Semgrep SAST
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 9 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  semgrep:
+    name: Semgrep
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    container:
+      image: semgrep/semgrep:1.140.0
+    # Skip on dependabot PRs — secrets aren't available there, would noise-fail.
+    if: github.actor != 'dependabot[bot]'
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Run Semgrep
+        run: semgrep ci
+        env:
+          # When set, fetches rules from semgrep.dev org and uploads findings
+          # to the dashboard. When unset, falls back to the auto config
+          # (community rules) without upload. Configure org-wide via
+          # gh secret set --org <org> --visibility all SEMGREP_APP_TOKEN
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}


### PR DESCRIPTION
## Summary

Adds Semgrep SAST alongside the existing CodeQL workflow. Semgrep + CodeQL together give complementary coverage:

- **CodeQL** — deep dataflow analysis, ~140 GitHub-curated rules, surfaces in repo Security tab
- **Semgrep** — pattern-based, broader rule ecosystem (community + custom org rules), centralized dashboard at [semgrep.dev](https://semgrep.dev) for cross-repo triage

Uses `semgrep ci` which:
- Pulls rules from semgrep.dev org config when `SEMGREP_APP_TOKEN` is set
- Falls back to `auto` config (community rules) when no token
- Diff-aware on PRs (only flags new findings)
- Uploads findings to dashboard when token present

Skips dependabot PRs (`if: github.actor != 'dependabot[bot]'`) since secrets aren't available there.

## Required next step (manual, by Drew)

After this merges, configure the org secret so all repos in this GitHub org pick it up:

```bash
# Generate token at https://semgrep.dev/orgs/<semgrep-org>/settings/tokens
gh secret set SEMGREP_APP_TOKEN --org <github-org> --visibility all --body "<token>"
```

Org mapping:
- `github.com/dcyfr/*` → `semgrep.dev/orgs/dcyfr_labs`
- `github.com/dcyfr-labs/*` → `semgrep.dev/orgs/dcyfr_labs`
- `github.com/gameshark-labs/*` → `semgrep.dev/orgs/gameshark_labs`

## Test plan

- [ ] First scheduled run completes in OSS mode (pre-token)
- [ ] After org secret added: findings appear in semgrep.dev dashboard
- [ ] No conflict with existing CodeQL workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)