### PR TITLE
fix(security): add fast-uri override to clear 2 high advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9060,9 +9060,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
   "overrides": {
     "postcss": "^8.5.10",
     "path-to-regexp": "^6.3.0",
-    "minimatch": ">=9.0.7"
+    "minimatch": ">=9.0.7",
+    "fast-uri": "^3.1.2"
   }
 }


### PR DESCRIPTION
## Summary

Add \`overrides.fast-uri = \"^3.1.2\"\` to clear both open Dependabot alerts:
- fast-uri vulnerable to path traversal via percent-encoded dot segments
- fast-uri vulnerable to host confusion via percent-encoded authority delimiters

Both are transitive via \`ajv\` (used by MCP SDK and Vercel microfrontends). The override forces resolution to the patched 3.1.2 line.

## Verification

\`\`\`
Before: 2 high
After:  0 high / 0 moderate / 0 critical
\`\`\`

## Test plan
- [ ] CI passes
- [ ] Dependabot alerts auto-close after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)