### PR TITLE
fix(release): use PAT with workflow scope for tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          # PAT with `workflow` scope when available — GITHUB_TOKEN cannot push
+          # tags on commits touching .github/workflows/* (server-side reject).
+          # Falls back cleanly; degraded mode no-ops tag push for such releases.
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary

Propagation of [dcyfr-ai-cli#91](https://github.com/dcyfr-labs/dcyfr-ai-cli/pull/91) and [dcyfr-ai#217](https://github.com/dcyfr-labs/dcyfr-ai/pull/217). Default `GITHUB_TOKEN` cannot push tags whose commits touch `.github/workflows/*`. Falls back to `GITHUB_TOKEN` when `RELEASE_TOKEN` secret is not set, so safe to merge before the secret is provisioned.

Where this repo has an explicit `git push --follow-tags` step, that push inherits credentials from `actions/checkout` — so swapping the checkout token fixes both flows in one change.

## ⚠️ Setup required after merge

Add fine-grained PAT as repo secret `RELEASE_TOKEN`:
- **Contents:** Read & write
- **Workflows:** Read & write

🤖 Generated with [Claude Code](https://claude.com/claude-code)