### PR TITLE
feat(release): mint tokens via dcyfr-labs-release GitHub App

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,19 @@ jobs:
     environment: production
     
     steps:
+      - name: Mint GitHub App token
+        id: app-token
+        # Only mint when org-level RELEASE_APP_ID is set. `continue-on-error`
+        # makes the workflow degrade-safe: if the App isn't installed on this
+        # repo yet, or secrets are missing, mint fails non-fatally and the
+        # fallback chain picks up RELEASE_TOKEN.
+        if: ${{ vars.RELEASE_APP_ID != '' }}
+        continue-on-error: true
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
@@ -28,7 +41,7 @@ jobs:
           # PAT with `workflow` scope when available — GITHUB_TOKEN cannot push
           # tags on commits touching .github/workflows/* (server-side reject).
           # Falls back cleanly; degraded mode no-ops tag push for such releases.
-          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token || secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary

Migrates release workflow from per-repo PAT (`RELEASE_TOKEN`) to org-level GitHub App token issuance via [`actions/create-github-app-token@v2`](https://github.com/actions/create-github-app-token).

- App: `dcyfr-labs-release` (id `3865506`), `contents:write` + `workflows:write` + `pull_requests:write`
- Triple fallback preserved: **App → PAT → GITHUB_TOKEN** — safe to merge before App is installed/secrets are set

## Degrade-safe

The Mint step uses `if: ${{ vars.RELEASE_APP_ID !=  }}` + `continue-on-error: true`. If the App is not yet installed on this repo or the org vars/secrets are missing, the mint step is skipped or fails non-fatally and the existing `RELEASE_TOKEN` path keeps working.

## Org activation (operator steps)

```bash
# 1. Install the App
open https://github.com/apps/dcyfr-labs-release/installations/new

# 2. Org variable (App ID is not secret)
gh variable set RELEASE_APP_ID --org dcyfr-labs --body 3865506 \
  --visibility selected --repos <list>

# 3. Org secret (the .pem you downloaded when you created the App)
gh secret set RELEASE_APP_PRIVATE_KEY --org dcyfr-labs \
  --visibility selected --repos <list> < path/to/private-key.pem
```

Once all three are in place, the next Release run uses the App token. `RELEASE_TOKEN` becomes dead weight; revoke when confident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)