### PR TITLE
fix(release): pin npm to 11.x so the release stops aborting on EBADENGINE

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,12 @@ jobs:
           npm install -D @changesets/cli @changesets/changelog-github --legacy-peer-deps
 
       - name: Upgrade npm for Trusted Publishing
-        run: npm install -g npm@latest
+        # Bounded to 11.x on purpose: npm 12 requires node
+        # `^22.22.2 || ^24.15.0 || >=26.0.0`, which the 24.13.0 pin above does not
+        # satisfy — so `npm@latest` aborts with EBADENGINE and fails the release
+        # outright. `^11` keeps the >=11.5 OIDC floor this step exists for.
+        # Widen once the node pin moves to >=24.15.0.
+        run: npm install -g npm@^11
 
       - name: Verify npm version for Trusted Publisher
         run: |


### PR DESCRIPTION
## What

Pins the release job to `npm@^11` instead of `npm@latest`.

## Why

The release job pins node to **24.13.0**, then runs `npm install -g npm@latest`
to guarantee the npm >=11.5 that OIDC Trusted Publishing needs.

npm **12** shipped between 2026-07-02 and 2026-07-12 with:

```
engines.node: ^22.22.2 || ^24.15.0 || >=26.0.0
```

24.13.0 sits *just* under the 24.x floor, so the OIDC guard step itself now
aborts with `EBADENGINE` and takes the whole release down with it. Releases on
`main` have failed fleet-wide across the `dcyfr-ai-*` repos since **2026-07-12**
(last green: 2026-07-02).

## Fix

`npm@^11` currently resolves to **11.19.0**, whose `engines.node` is
`^20.17.0 || >=22.9.0` — satisfied by the 24.13.0 pin. It keeps the >=11.5 OIDC
floor this step exists for, and unlike a floating `@latest` it cannot drift
across a node-engine ceiling again.

## Verification

Reproduced and fixed locally on **node v24.13.0** — the exact version this
workflow pins:

```
$ npm install -g npm@latest --dry-run
npm error code EBADENGINE
npm error notsup Not compatible with your version of node/npm: npm@12.0.2
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"11.6.2","node":"v24.13.0"}

$ npm install -g npm@^11 --dry-run
removed 60 packages, and changed 93 packages in 11s   # ok
```

- `actionlint` — no new findings vs `origin/main`
- one file changed; no other workflow or source touched

## Alternative considered

Bumping the node pin to >=24.15.0 would also let `npm@latest` install, but it
changes the runtime for build-and-test too and 24.13.0 matches local dev. Once
that pin moves, `npm@latest` becomes safe again — noted in an inline comment.

> Note: the commit message on this branch cites `11.9.0` as the `^11`
> resolution; the correct current value is **11.19.0** (both carry identical
> `engines.node`, so the fix is unaffected). Not amended to avoid a force-push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014HxV2VX6vc7m8LkMGUgyAu