### PR TITLE
fix(deps): make the postcss override track the direct dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
   },
   "homepage": "https://github.com/dcyfr-labs/dcyfr-ai-web#readme",
   "overrides": {
-    "postcss": "^8.5.10",
+    "postcss": "$postcss",
     "path-to-regexp": "^6.3.0",
     "minimatch": ">=9.0.7",
     "fast-uri": "^3.1.4",


### PR DESCRIPTION
## What was broken

Dependabot security updates have been failing on every run in this repo:

```
npm error code EOVERRIDE
npm error Override for postcss@8.5.25 conflicts with direct dependency
```

`postcss` is pinned in two places — as a direct `devDependency` and again in
`overrides` — both at the literal `^8.5.10`. npm only permits an override on a
package you directly depend on while the two specs match **exactly**. So the
moment Dependabot bumps the direct dep, the literal override is stale and npm
refuses to resolve a lockfile at all. The update aborts before it can open a
PR, which is why the same advisories kept re-firing with nothing to show for it.

This was the root cause behind the bulk of the "real CI failures" in triage —
the same stale-override pattern was present in **8 dcyfr-labs repos**.

## The fix

One line: use npm's `$postcss` reference form, so the override resolves to
whatever the direct dependency is and the two can never drift apart again.
This is the idiom npm documents for exactly this case, and it is already
house style here (`"eslint-config-next": {"eslint": "$eslint"}` in dcyfr-labs).

The pin still does its job — transitive postcss still collapses to a single
hoisted copy.

## Verification

- Reproduced `EOVERRIDE` against a simulated Dependabot bump (direct dep to
  `^8.5.25`, override left literal) — fails exactly as CI does.
- Same bump with the `$`-form resolves cleanly and hoists one `postcss@8.5.25`.
- Current-state resolve is clean.

`package-lock.json` is deliberately **untouched**: this change produces no
lockfile delta. (Regenerating it locally on macOS strips `libc: ["glibc"]`
platform metadata from ~199 lines, which would break Linux `npm ci` — that
churn is pre-existing npm-version drift and is left well alone.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnRaA9mr9wjosyMFQda5yN