### PR TITLE
fix(ci): scope the weekly Semgrep sweep to Code so it stops OOMing

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -24,7 +24,13 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run Semgrep
-        run: semgrep ci
+        # The weekly full-repo sweep was being SIGKILLed (exit 137) partway through
+        # loading the ~85k Supply Chain rules: the hosted-runner image bump on
+        # 2026-07-20 left the job short of memory, and every scheduled run in every
+        # repo has failed since. Dependabot already owns supply-chain alerting here,
+        # so the cron scans Code (SAST) only. PR runs are diff-scans, small enough
+        # to keep both products, and remain the pre-merge gate.
+        run: semgrep ci ${{ github.event_name == 'schedule' && '--code' || '' }}
         env:
           # When set, fetches rules from semgrep.dev org and uploads findings
           # to the dashboard. When unset, falls back to the auto config


### PR DESCRIPTION
## What was broken

Every **scheduled** Semgrep run, in every repo carrying this workflow, has
failed since 2026-07-27:

```
##[error]The runner has received a shutdown signal...
##[error]Process completed with exit code 137.
```

Exit 137 is a SIGKILL. The job dies ~90s after the Pro engine loads — before
it ever reaches the `Scanning N files` line.

## What it isn't

Ruled out by measurement, so nobody re-derives these:

| Hypothesis | Verdict |
|---|---|
| Actions billing | **No** — August minutes bill out at `$0.01`, essentially all free-tier |
| Repo size | **No** — a 37-file repo dies identically to the workspace monorepo, at the same ~90s mark |
| Workflow change | **No** — `semgrep.yml` untouched since 2026-06-26 |
| Semgrep Pro newly enabled | **No** — the last *passing* cron used the same Pro 1.140.0 and the same enabled products |

## What it is

The GitHub hosted-runner image bumped **`20260714.240.1`** (last pass) →
**`20260720.247.2`** (every failure since). The last good run shows the load
the job carries: **2,944 Code rules + 85,621 Supply Chain rules**, ~3 minutes
of rule loading before scanning starts. That used to just fit. On the new
image it doesn't, and the container is killed mid-load.

## The fix

The weekly sweep now runs **Semgrep Code only**. Dependabot already owns
supply-chain alerting across these repos, so this hands supply chain to the
tool already doing it rather than duplicating it in a job that can no longer
afford the memory.

```yaml
run: semgrep ci ${{ github.event_name == 'schedule' && '--code' || '' }}
```

**Pull-request runs are deliberately untouched.** They are diff-scans, small
enough to keep both products, they never failed, and they remain the pre-merge
gate. Only the full-repo cron changes.

## Verification

- `semgrep ci --code` runs clean in the pinned `semgrep/semgrep:1.140.0` image:
  **1,074 rules** vs **88,565** for the full product set.
- `--code` confirmed against the pinned image's own help: *"Run Semgrep Code
  (SAST) product."*
- `actionlint` clean on the changed workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnRaA9mr9wjosyMFQda5yN
